### PR TITLE
Clarify English locale on filtering settings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -779,10 +779,10 @@ en:
           none: Nobody can sign up
           open: Anyone can sign up
       reject_blurhash:
-        desc_html: Set a blurhashes to inspect Create Activity media attachments, and refuse Activity if you match
+        desc_html: Blurhashes to compare against Create activities' media attachments. Matching activities will be rejected. Separated by newline.
         title: Reject blurhash
       reject_pattern:
-        desc_html: Set a regular expression pattern to inspect Create Activity content, and refuse Activity if you match
+        desc_html: Regular expression pattern to match against Create activities. Matching activities will be rejected. Must be a single pattern.
         title: Reject Pattern
       security:
         authorized_fetch: Require authentication from federated servers


### PR DESCRIPTION
We've applied this patch over on Catstodon/CatCatNya~, and are very grateful for its existence ^^

However, the description for the English locale is a bit unclear. I've clarified it a bit.

You should adjust the detail of "the regex pattern must be a single one" and "separate the blurhashes by newlines" in `ja.yml` separately, as it isn't specified there either.